### PR TITLE
Abstract calls to digitalWrite and pinMode from the outside "world" by making virtual protected methods

### DIFF
--- a/src/LiquidCrystal.cpp
+++ b/src/LiquidCrystal.cpp
@@ -324,3 +324,10 @@ void LiquidCrystal::write8bits(uint8_t value) {
   
   pulseEnable();
 }
+
+void LiquidCrystal::digitalWrite(int pin, int value) {
+    ::digitalWrite(pin, value);
+}
+void LiquidCrystal::pinMode(int pin, int mode) {
+    ::pinMode(pin, mode);
+}

--- a/src/LiquidCrystal.h
+++ b/src/LiquidCrystal.h
@@ -84,6 +84,9 @@ public:
   void command(uint8_t);
   
   using Print::write;
+protected:
+  virtual void digitalWrite(int pin, int value);
+  virtual void pinMode(int pin, int mode);
 private:
   void send(uint8_t, uint8_t);
   void write4bits(uint8_t);


### PR DESCRIPTION
After seeing the Adafruit RGBLCDShield I wanted to do the same thing over SPI (using an MCP23S17) but found that the LiquidCrystal library is written to favor code duplication over inheritance. After doing some experiments I found that only digitalWrite and pinMode need to become virtual inside the class. This change does _not_ break the external interface nor internal design in any way.

