### PR TITLE
Issue #6 fixed and reading functions added

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -31,6 +31,8 @@ scrollDisplayLeft	KEYWORD2
 scrollDisplayRight	KEYWORD2
 createChar	KEYWORD2
 setRowOffsets	KEYWORD2
+readBFAddr  KEYWORD2
+readRAM KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/keywords.txt
+++ b/keywords.txt
@@ -11,7 +11,7 @@ LiquidCrystal	KEYWORD1	LiquidCrystal
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-	
+
 begin	KEYWORD2
 clear	KEYWORD2
 home	KEYWORD2

--- a/keywords.txt
+++ b/keywords.txt
@@ -11,7 +11,7 @@ LiquidCrystal	KEYWORD1	LiquidCrystal
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-
+	
 begin	KEYWORD2
 clear	KEYWORD2
 home	KEYWORD2
@@ -31,8 +31,8 @@ scrollDisplayLeft	KEYWORD2
 scrollDisplayRight	KEYWORD2
 createChar	KEYWORD2
 setRowOffsets	KEYWORD2
-readBFAddr  KEYWORD2
-readRAM KEYWORD2
+readBFAddr	KEYWORD2
+readRAM	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)

--- a/src/LiquidCrystal.cpp
+++ b/src/LiquidCrystal.cpp
@@ -275,10 +275,10 @@ void LiquidCrystal::createChar(uint8_t location, uint8_t charmap[]) {
 
 /*********** mid level commands, for sending data/cmds */
 
-inline uint8_t LiquidCrystal::readBFAddr(void) {
+inline int LiquidCrystal::readBFAddr(void) {
   return read(LOW);
 }
-inline uint8_t LiquidCrystal::readRAM(void) {
+int LiquidCrystal::readRAM(void) {
   return read(HIGH);
 }
 

--- a/src/LiquidCrystal.cpp
+++ b/src/LiquidCrystal.cpp
@@ -263,7 +263,7 @@ void LiquidCrystal::noAutoscroll(void) {
 // Allows us to fill the first 8 CGRAM locations
 // with custom characters
 void LiquidCrystal::createChar(uint8_t location, uint8_t charmap[]) {
-  int ramAddr = read_BF_addr();
+  int ramAddr = readBFAddr();
   location &= 0x7; // we only have 8 locations 0-7
   command(LCD_SETCGRAMADDR | (location << 3));
   for (int i=0; i<8; i++) {
@@ -275,10 +275,10 @@ void LiquidCrystal::createChar(uint8_t location, uint8_t charmap[]) {
 
 /*********** mid level commands, for sending data/cmds */
 
-inline uint8_t LiquidCrystal::read_BF_addr(void) {
+inline uint8_t LiquidCrystal::readBFAddr(void) {
   return read(LOW);
 }
-inline uint8_t LiquidCrystal::read_RAM(void) {
+inline uint8_t LiquidCrystal::readRAM(void) {
   return read(HIGH);
 }
 
@@ -330,7 +330,7 @@ int LiquidCrystal::read(bool mode) {
       address = read4bits();
     }
 
-     for (int i=0; i<((_displayfunction & LCD_8BITMODE) ? 8 : 4); ++i)
+    for (int i=0; i<((_displayfunction & LCD_8BITMODE) ? 8 : 4); ++i)
     {
       pinMode(_data_pins[i], OUTPUT);
     }

--- a/src/LiquidCrystal.h
+++ b/src/LiquidCrystal.h
@@ -90,6 +90,7 @@ private:
   void send(uint8_t, uint8_t);
   void write4bits(uint8_t);
   void write8bits(uint8_t);
+  int read(bool);
   uint8_t read4bits();
   uint8_t read8bits();
   void pulseEnable();

--- a/src/LiquidCrystal.h
+++ b/src/LiquidCrystal.h
@@ -82,12 +82,16 @@ public:
   void setCursor(uint8_t, uint8_t); 
   virtual size_t write(uint8_t);
   void command(uint8_t);
+  uint8_t read_BF_addr(void);
+  uint8_t read_RAM(void);
   
   using Print::write;
 private:
   void send(uint8_t, uint8_t);
   void write4bits(uint8_t);
   void write8bits(uint8_t);
+  uint8_t read4bits();
+  uint8_t read8bits();
   void pulseEnable();
 
   uint8_t _rs_pin; // LOW: command.  HIGH: character.

--- a/src/LiquidCrystal.h
+++ b/src/LiquidCrystal.h
@@ -82,8 +82,8 @@ public:
   void setCursor(uint8_t, uint8_t); 
   virtual size_t write(uint8_t);
   void command(uint8_t);
-  uint8_t read_BF_addr(void);
-  uint8_t read_RAM(void);
+  uint8_t readBFAaddr(void);
+  uint8_t readRAM(void);
   
   using Print::write;
 private:

--- a/src/LiquidCrystal.h
+++ b/src/LiquidCrystal.h
@@ -82,8 +82,8 @@ public:
   void setCursor(uint8_t, uint8_t); 
   virtual size_t write(uint8_t);
   void command(uint8_t);
-  uint8_t readBFAddr(void);
-  uint8_t readRAM(void);
+  int readBFAddr(void);
+  int readRAM(void);
   
   using Print::write;
 private:

--- a/src/LiquidCrystal.h
+++ b/src/LiquidCrystal.h
@@ -82,7 +82,7 @@ public:
   void setCursor(uint8_t, uint8_t); 
   virtual size_t write(uint8_t);
   void command(uint8_t);
-  uint8_t readBFAaddr(void);
+  uint8_t readBFAddr(void);
   uint8_t readRAM(void);
   
   using Print::write;


### PR DESCRIPTION
Issue #6 was that createchar() function leave data address in CGRAM position. After that, begin(), setCursor(),clear() or home() functions must be executed before write() function in order for it to work. It is fixed but require rw pin to be set for it to work. This is because, when address register goes to CGRAM, there is no record of its previous position in our MCU. MCU must read its previous position in order for it to go back. In case rw pin is not specified, the register is not returned and it cannot untill rw is specified.

Also Added following functions,
read_BF_addr
read_RAM
read
read4bits
read8bits