### PR TITLE
Remove redundant spaces from comment text

### DIFF
--- a/examples/Autoscroll/Autoscroll.ino
+++ b/examples/Autoscroll/Autoscroll.ino
@@ -1,7 +1,7 @@
 /*
   LiquidCrystal Library - Autoscroll
 
- Demonstrates the use of a 16x2 LCD display.  The LiquidCrystal
+ Demonstrates the use of a 16x2 LCD display. The LiquidCrystal
  library works with all LCD displays that are compatible with the
  Hitachi HD44780 driver. There are many of them out there, and you
  can usually tell them by the 16-pin interface.

--- a/examples/Blink/Blink.ino
+++ b/examples/Blink/Blink.ino
@@ -1,7 +1,7 @@
 /*
   LiquidCrystal Library - Blink
 
- Demonstrates the use of a 16x2 LCD display.  The LiquidCrystal
+ Demonstrates the use of a 16x2 LCD display. The LiquidCrystal
  library works with all LCD displays that are compatible with the
  Hitachi HD44780 driver. There are many of them out there, and you
  can usually tell them by the 16-pin interface.

--- a/examples/Cursor/Cursor.ino
+++ b/examples/Cursor/Cursor.ino
@@ -1,13 +1,13 @@
 /*
   LiquidCrystal Library - Cursor
 
- Demonstrates the use of a 16x2 LCD display.  The LiquidCrystal
+ Demonstrates the use of a 16x2 LCD display. The LiquidCrystal
  library works with all LCD displays that are compatible with the
  Hitachi HD44780 driver. There are many of them out there, and you
  can usually tell them by the 16-pin interface.
 
  This sketch prints "hello, world!" to the LCD and
- uses the cursor()  and noCursor() methods to turn
+ uses the cursor() and noCursor() methods to turn
  on and off the cursor.
 
  The circuit:

--- a/examples/CustomCharacter/CustomCharacter.ino
+++ b/examples/CustomCharacter/CustomCharacter.ino
@@ -1,7 +1,7 @@
 /*
   LiquidCrystal Library - Custom Characters
 
- Demonstrates how to add custom characters on an LCD  display.
+ Demonstrates how to add custom characters on an LCD display.
  The LiquidCrystal library works with all LCD displays that are
  compatible with the Hitachi HD44780 driver. There are many of
  them out there, and you can usually tell them by the 16-pin interface.

--- a/examples/Display/Display.ino
+++ b/examples/Display/Display.ino
@@ -1,7 +1,7 @@
 /*
   LiquidCrystal Library - display() and noDisplay()
 
- Demonstrates the use of a 16x2 LCD display.  The LiquidCrystal
+ Demonstrates the use of a 16x2 LCD display. The LiquidCrystal
  library works with all LCD displays that are compatible with the
  Hitachi HD44780 driver. There are many of them out there, and you
  can usually tell them by the 16-pin interface.

--- a/examples/HelloWorld/HelloWorld.ino
+++ b/examples/HelloWorld/HelloWorld.ino
@@ -1,7 +1,7 @@
 /*
   LiquidCrystal Library - Hello World
 
- Demonstrates the use of a 16x2 LCD display.  The LiquidCrystal
+ Demonstrates the use of a 16x2 LCD display. The LiquidCrystal
  library works with all LCD displays that are compatible with the
  Hitachi HD44780 driver. There are many of them out there, and you
  can usually tell them by the 16-pin interface.

--- a/examples/Scroll/Scroll.ino
+++ b/examples/Scroll/Scroll.ino
@@ -1,7 +1,7 @@
 /*
   LiquidCrystal Library - scrollDisplayLeft() and scrollDisplayRight()
 
- Demonstrates the use of a 16x2 LCD display.  The LiquidCrystal
+ Demonstrates the use of a 16x2 LCD display. The LiquidCrystal
  library works with all LCD displays that are compatible with the
  Hitachi HD44780 driver. There are many of them out there, and you
  can usually tell them by the 16-pin interface.

--- a/examples/SerialDisplay/SerialDisplay.ino
+++ b/examples/SerialDisplay/SerialDisplay.ino
@@ -1,7 +1,7 @@
 /*
   LiquidCrystal Library - Serial Input
 
- Demonstrates the use of a 16x2 LCD display.  The LiquidCrystal
+ Demonstrates the use of a 16x2 LCD display. The LiquidCrystal
  library works with all LCD displays that are compatible with the
  Hitachi HD44780 driver. There are many of them out there, and you
  can usually tell them by the 16-pin interface.

--- a/examples/TextDirection/TextDirection.ino
+++ b/examples/TextDirection/TextDirection.ino
@@ -1,7 +1,7 @@
 /*
  LiquidCrystal Library - TextDirection
 
- Demonstrates the use of a 16x2 LCD display.  The LiquidCrystal
+ Demonstrates the use of a 16x2 LCD display. The LiquidCrystal
  library works with all LCD displays that are compatible with the
  Hitachi HD44780 driver. There are many of them out there, and you
  can usually tell them by the 16-pin interface.

--- a/examples/setCursor/setCursor.ino
+++ b/examples/setCursor/setCursor.ino
@@ -1,7 +1,7 @@
 /*
   LiquidCrystal Library - setCursor
 
- Demonstrates the use of a 16x2 LCD display.  The LiquidCrystal
+ Demonstrates the use of a 16x2 LCD display. The LiquidCrystal
  library works with all LCD displays that are compatible with the
  Hitachi HD44780 driver. There are many of them out there, and you
  can usually tell them by the 16-pin interface.
@@ -46,7 +46,7 @@
 const int rs = 12, en = 11, d4 = 5, d5 = 4, d6 = 3, d7 = 2;
 LiquidCrystal lcd(rs, en, d4, d5, d6, d7);
 
-// these constants won't change.  But you can change the size of
+// these constants won't change. But you can change the size of
 // your LCD using them:
 const int numRows = 2;
 const int numCols = 16;

--- a/src/LiquidCrystal.h
+++ b/src/LiquidCrystal.h
@@ -90,8 +90,8 @@ private:
   void write8bits(uint8_t);
   void pulseEnable();
 
-  uint8_t _rs_pin; // LOW: command.  HIGH: character.
-  uint8_t _rw_pin; // LOW: write to LCD.  HIGH: read from LCD.
+  uint8_t _rs_pin; // LOW: command. HIGH: character.
+  uint8_t _rw_pin; // LOW: write to LCD. HIGH: read from LCD.
   uint8_t _enable_pin; // activated by a HIGH pulse.
   uint8_t _data_pins[8];
 


### PR DESCRIPTION
Some redundant spaces were present in the comments

Some of these followed a period. Although two spaces after a period were sometimes recommended in previous eras, modern practice is universally a single space:

https://www.chicagomanualofstyle.org/qanda/data/faq/topics/OneSpaceorTwo/faq0006.html

Regardless of whether it is correct according to standard practice, it might be reasonable to retain double spaces if this were a well established convention in the project. That is not the case here. The majority of the content uses only a single space, so the double spaces are inconsistent in addition to being incorrect.

There were also some occurrences of redundant spaces within sentences, which is never correct.

Resolves (partially) https://github.com/arduino-libraries/LiquidCrystal/issues/8