### PR TITLE
Update api.md to reflect documentation support for 5x10 displays

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -51,7 +51,7 @@ Initializes the interface to the LCD screen, and specifies the dimensions (width
 #### Syntax
 
 ```
-lcd.begin(cols, rows [, charsize[=LCD_5x10DOTS]])
+lcd.begin(cols, rows, charsize)
 ```
 
 #### Parameters
@@ -61,7 +61,7 @@ cols: the number of columns that the display has
 
 rows: the number of rows that the display has
 
-charsize: the number of dots that the display has (default: LCD_5x8DOTS)
+charsize (optional): the number of dots the display has per character: LCD_5x8DOTS for 5x8, LCD_5x10DOTS for 5x10. (default: LCD_5x8DOTS)
 
 ### `clear()`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -51,7 +51,7 @@ Initializes the interface to the LCD screen, and specifies the dimensions (width
 #### Syntax
 
 ```
-lcd.begin(cols, rows)
+lcd.begin(cols, rows, charsize)
 ```
 
 #### Parameters
@@ -60,6 +60,8 @@ lcd: a variable of type LiquidCrystal
 cols: the number of columns that the display has
 
 rows: the number of rows that the display has
+
+charsize: the number of dots that the display has, the usual LCD_5x8DOTS or LCD_5x10DOTS
 
 ### `clear()`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -51,7 +51,7 @@ Initializes the interface to the LCD screen, and specifies the dimensions (width
 #### Syntax
 
 ```
-lcd.begin(cols, rows, [, charsize[=LCD_5x10DOTS]])
+lcd.begin(cols, rows [, charsize[=LCD_5x10DOTS]])
 ```
 
 #### Parameters

--- a/docs/api.md
+++ b/docs/api.md
@@ -51,7 +51,7 @@ Initializes the interface to the LCD screen, and specifies the dimensions (width
 #### Syntax
 
 ```
-lcd.begin(cols, rows, charsize)
+lcd.begin(cols, rows, [, charsize[=LCD_5x10DOTS]])
 ```
 
 #### Parameters
@@ -61,7 +61,7 @@ cols: the number of columns that the display has
 
 rows: the number of rows that the display has
 
-charsize: the number of dots that the display has, the usual LCD_5x8DOTS or LCD_5x10DOTS
+charsize: the number of dots that the display has (default: LCD_5x8DOTS)
 
 ### `clear()`
 


### PR DESCRIPTION
Found this [issue](https://github.com/arduino/Arduino/issues/5563#issue-187484965) in the [arduino/Arduino](https://github.com/arduino/Arduino) repository where a user had trouble finding the documentation for her unique 1-line 5x10 char LCD display in the LiquidCrystal references page since she could not satisfactorily display the extended 32 characters due to the default charsize value in:

`void begin(uint8_t cols, uint8_t rows, uint8_t charsize = LCD_5x8DOTS);`

They had to manually dig into the source code to find [this method](https://github.com/arduino-libraries/LiquidCrystal/blob/1.0.4/src/LiquidCrystal.h#L62) and define the extended 5x10 font support.

This commit should help users with similar boards get started easily with the LiquidCrystal library using the overloaded begin() invocation with relevant docs available on the website, without any need to painstakingly go through the source code.