### PR TITLE
Mark character lines array as const

### DIFF
--- a/src/LiquidCrystal.cpp
+++ b/src/LiquidCrystal.cpp
@@ -262,7 +262,7 @@ void LiquidCrystal::noAutoscroll(void) {
 
 // Allows us to fill the first 8 CGRAM locations
 // with custom characters
-void LiquidCrystal::createChar(uint8_t location, uint8_t charmap[]) {
+void LiquidCrystal::createChar(uint8_t location, const uint8_t charmap[]) {
   location &= 0x7; // we only have 8 locations 0-7
   command(LCD_SETCGRAMADDR | (location << 3));
   for (int i=0; i<8; i++) {

--- a/src/LiquidCrystal.h
+++ b/src/LiquidCrystal.h
@@ -78,7 +78,7 @@ public:
   void noAutoscroll();
 
   void setRowOffsets(int row1, int row2, int row3, int row4);
-  void createChar(uint8_t, uint8_t[]);
+  void createChar(uint8_t, const uint8_t[]);
   void setCursor(uint8_t, uint8_t); 
   virtual size_t write(uint8_t);
   void command(uint8_t);


### PR DESCRIPTION
Characters lines may be defined as static constexpr arrays in a client application, but passing the data to the LiquidLibrary requires a const_cast because it is not flagged const in the API, even if in practice uint8_t are not modified. 

This PR will allow to remove the const_cast in client code.